### PR TITLE
feat(core): add IGW and public/private route tables with subnet assoc…

### DIFF
--- a/infra/core/dev/igw.tf
+++ b/infra/core/dev/igw.tf
@@ -1,0 +1,6 @@
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags = {
+    Name = "${var.project_name}-igw-${var.env}"
+  }
+}

--- a/infra/core/dev/route-tables.tf
+++ b/infra/core/dev/route-tables.tf
@@ -1,0 +1,32 @@
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.this.id
+  tags = {
+    Name = "${var.project_name}-public-rt-${var.env}"
+  }
+}
+
+resource "aws_route_table_association" "public_rt_assoc" {
+  for_each       = { for k, v in local.subnets : k => v if v.component == "edge" }
+  subnet_id      = aws_subnet.this[each.key].id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+// Create a default route for the public route table to the internet gateway
+resource "aws_route" "public_rt_default_route" {
+  route_table_id         = aws_route_table.public_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.this.id
+  tags = {
+    Name = "${var.project_name}-private-rt-${var.env}"
+  }
+}
+
+resource "aws_route_table_association" "private_rt_assoc" {
+  for_each       = { for k, v in local.subnets : k => v if v.tier == "private" }
+  subnet_id      = aws_subnet.this[each.key].id
+  route_table_id = aws_route_table.private_rt.id
+}

--- a/infra/core/prod/igw.tf
+++ b/infra/core/prod/igw.tf
@@ -1,0 +1,6 @@
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags = {
+    Name = "${var.project_name}-igw-${var.env}"
+  }
+}

--- a/infra/core/prod/route-tables.tf
+++ b/infra/core/prod/route-tables.tf
@@ -1,0 +1,32 @@
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.this.id
+  tags = {
+    Name = "${var.project_name}-public-rt-${var.env}"
+  }
+}
+
+resource "aws_route_table_association" "public_rt_assoc" {
+  for_each       = { for k, v in local.subnets : k => v if v.component == "edge" }
+  subnet_id      = aws_subnet.this[each.key].id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+// Create a default route for the public route table to the internet gateway
+resource "aws_route" "public_rt_default_route" {
+  route_table_id         = aws_route_table.public_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.this.id
+  tags = {
+    Name = "${var.project_name}-private-rt-${var.env}"
+  }
+}
+
+resource "aws_route_table_association" "private_rt_assoc" {
+  for_each       = { for k, v in local.subnets : k => v if v.tier == "private" }
+  subnet_id      = aws_subnet.this[each.key].id
+  route_table_id = aws_route_table.private_rt.id
+}


### PR DESCRIPTION
Configured baseline routing for dev and prod VPCs:

- Created an Internet Gateway per VPC
- Added a public route table with default route 0.0.0.0/0 -> IGW
- Added a private route table (local-only)
- Associated public subnets to the public route table
- Associated private app/data subnets to the private route table

This establishes public vs private subnet behavior without introducing NAT Gateways.