### PR TITLE
feat(runtime): add ALB, Target Group and Listener in dev and prod env…

### DIFF
--- a/infra/runtime/dev/.terraform.lock.hcl
+++ b/infra/runtime/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/runtime/dev/alb.tf
+++ b/infra/runtime/dev/alb.tf
@@ -1,0 +1,43 @@
+resource "aws_lb" "this" {
+  name               = "${var.project_name}-alb-${var.env}"
+  internal           = false
+  security_groups    = [data.terraform_remote_state.core.outputs.security_group_alb]
+  load_balancer_type = "application"
+  subnets            = data.terraform_remote_state.core.outputs.subnet_ids_public
+
+  tags = {
+    Name = "${var.project_name}-alb-${var.env}"
+  }
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = "${var.project_name}-tg-${var.env}"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = data.terraform_remote_state.core.outputs.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = var.health_check_path
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    matcher             = "200"
+  }
+
+  tags = {
+    Name = "${var.project_name}-tg-${var.env}"
+  }
+}
+
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}

--- a/infra/runtime/dev/data.tf
+++ b/infra/runtime/dev/data.tf
@@ -1,0 +1,9 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+
+  config = {
+    bucket = "url-shortener-saa-tfstate-shared-792025037142"
+    key    = "${var.env}/core/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/infra/runtime/dev/main.tf
+++ b/infra/runtime/dev/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = "~> 1.14.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Owner       = "André Santos"
+      Environment = var.env
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/infra/runtime/dev/outputs.tf
+++ b/infra/runtime/dev/outputs.tf
@@ -1,0 +1,7 @@
+output "alb_dns_name" {
+  value = aws_lb.this.dns_name
+}
+
+output "target_group_arn" {
+  value = aws_lb_target_group.this.arn
+}

--- a/infra/runtime/dev/terraform.tfvars
+++ b/infra/runtime/dev/terraform.tfvars
@@ -1,0 +1,4 @@
+project_name      = "url-shortener-saa"
+env               = "dev"
+container_port    = 8000
+health_check_path = "/api/health/ready"

--- a/infra/runtime/dev/variables.tf
+++ b/infra/runtime/dev/variables.tf
@@ -1,0 +1,25 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "env" {
+  description = "Environment"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port"
+  type        = number
+}
+
+variable "health_check_path" {
+  description = "Health check path"
+  type        = string
+}

--- a/infra/runtime/prod/.terraform.lock.hcl
+++ b/infra/runtime/prod/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/runtime/prod/alb.tf
+++ b/infra/runtime/prod/alb.tf
@@ -1,0 +1,43 @@
+resource "aws_lb" "this" {
+  name               = "${var.project_name}-alb-${var.env}"
+  internal           = false
+  security_groups    = [data.terraform_remote_state.core.outputs.security_group_alb]
+  load_balancer_type = "application"
+  subnets            = data.terraform_remote_state.core.outputs.subnet_ids_public
+
+  tags = {
+    Name = "${var.project_name}-alb-${var.env}"
+  }
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = "${var.project_name}-tg-${var.env}"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = data.terraform_remote_state.core.outputs.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = var.health_check_path
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    matcher             = "200"
+  }
+
+  tags = {
+    Name = "${var.project_name}-tg-${var.env}"
+  }
+}
+
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}

--- a/infra/runtime/prod/data.tf
+++ b/infra/runtime/prod/data.tf
@@ -1,0 +1,9 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+
+  config = {
+    bucket = "url-shortener-saa-tfstate-shared-792025037142"
+    key    = "${var.env}/core/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/infra/runtime/prod/main.tf
+++ b/infra/runtime/prod/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = "~> 1.14.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Owner       = "André Santos"
+      Environment = var.env
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/infra/runtime/prod/outputs.tf
+++ b/infra/runtime/prod/outputs.tf
@@ -1,0 +1,7 @@
+output "alb_dns_name" {
+  value = aws_lb.this.dns_name
+}
+
+output "target_group_arn" {
+  value = aws_lb_target_group.this.arn
+}

--- a/infra/runtime/prod/terraform.tfvars
+++ b/infra/runtime/prod/terraform.tfvars
@@ -1,0 +1,4 @@
+project_name      = "url-shortener-saa"
+env               = "prod"
+container_port    = 8000
+health_check_path = "/api/health/ready"

--- a/infra/runtime/prod/variables.tf
+++ b/infra/runtime/prod/variables.tf
@@ -1,0 +1,25 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "env" {
+  description = "Environment"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port"
+  type        = number
+}
+
+variable "health_check_path" {
+  description = "Health check path"
+  type        = string
+}


### PR DESCRIPTION
Provisioned an internet-facing Application Load Balancer (ALB) across two public subnets in the `dev` environment as part of the Runtime Layer (M3).

This ALB will serve as the entry point for the URL Shortener service (ECS/Fargate) in subsequent issues.