### PR TITLE
feat(runtime): deploy MVP URL shortener behind ALB and stabilize to s…

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, HttpUrl
+
+app = FastAPI(title="URL Shortener (MVP)")
+
+# In-memory storage (MVP only). This will reset on task restart and won't be shared across tasks.
+URL_STORE: Dict[str, str] = {}
+
+
+class ShortenRequest(BaseModel):
+    url: HttpUrl
+
+
+class ShortenResponse(BaseModel):
+    code: str
+    short_url: str
+
+
+@app.get("/api/health/ready")
+def ready() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/api/shorten", response_model=ShortenResponse)
+def shorten(req: ShortenRequest) -> ShortenResponse:
+    # Create a short code. Collisions are extremely unlikely for this MVP.
+    code = secrets.token_urlsafe(6).replace("-", "").replace("_", "")[:8]
+    URL_STORE[code] = str(req.url)
+
+    # Optional: allow overriding the base URL via env var (useful for prod ALB DNS)
+    base_url = os.getenv("BASE_URL", "").rstrip("/")
+    short_url = f"{base_url}/{code}" if base_url else f"/{code}"
+
+    return ShortenResponse(code=code, short_url=short_url)
+
+
+@app.get("/{code}")
+def redirect(code: str):
+    url = URL_STORE.get(code)
+    if not url:
+        raise HTTPException(status_code=404, detail="Short code not found")
+
+    # 307 keeps method (safe default). 302 is also fine for typical shorteners.
+    return RedirectResponse(url=url, status_code=307)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.8.2

--- a/infra/runtime/dev/ecs.tf
+++ b/infra/runtime/dev/ecs.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_task_definition" "this" {
   container_definitions = jsonencode([
     {
       name      = "app"
-      image     = "${var.repository}/${var.project_name}-${var.env}:latest"
+      image     = "${var.repository}/${var.project_name}-${var.env}:${var.image_tag}"
       essential = true
       portMappings = [
         {
@@ -37,7 +37,7 @@ resource "aws_ecs_service" "this" {
   name            = "${var.project_name}-service-${var.env}"
   cluster         = aws_ecs_cluster.this.id
   task_definition = aws_ecs_task_definition.this.arn
-  desired_count   = 1
+  desired_count   = var.desired_count
   launch_type     = "FARGATE"
 
   deployment_minimum_healthy_percent = 100

--- a/infra/runtime/dev/terraform.tfvars
+++ b/infra/runtime/dev/terraform.tfvars
@@ -3,3 +3,5 @@ env               = "dev"
 container_port    = 8000
 health_check_path = "/api/health/ready"
 repository        = "792025037142.dkr.ecr.us-east-1.amazonaws.com"
+image_tag = "v0.1.0"
+desired_count = 1

--- a/infra/runtime/dev/variables.tf
+++ b/infra/runtime/dev/variables.tf
@@ -28,3 +28,13 @@ variable "repository" {
   description = "ECR repository URL"
   type        = string
 }
+
+variable "image_tag" {
+  description = "ECR image tag"
+  type        = string
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Number of tasks to run."
+}

--- a/infra/runtime/prod/ecs.tf
+++ b/infra/runtime/prod/ecs.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_task_definition" "this" {
   container_definitions = jsonencode([
     {
       name      = "app"
-      image     = "${var.repository}/${var.project_name}-${var.env}:latest"
+      image     = "${var.repository}/${var.project_name}-${var.env}:${var.image_tag}"
       essential = true
       portMappings = [
         {
@@ -37,7 +37,7 @@ resource "aws_ecs_service" "this" {
   name            = "${var.project_name}-service-${var.env}"
   cluster         = aws_ecs_cluster.this.id
   task_definition = aws_ecs_task_definition.this.arn
-  desired_count   = 2
+  desired_count   = var.desired_count
   launch_type     = "FARGATE"
 
   deployment_minimum_healthy_percent = 100

--- a/infra/runtime/prod/terraform.tfvars
+++ b/infra/runtime/prod/terraform.tfvars
@@ -3,3 +3,5 @@ env               = "prod"
 container_port    = 8000
 health_check_path = "/api/health/ready"
 repository        = "792025037142.dkr.ecr.us-east-1.amazonaws.com"
+image_tag = "v0.1.0"
+desired_count = 1

--- a/infra/runtime/prod/variables.tf
+++ b/infra/runtime/prod/variables.tf
@@ -28,3 +28,13 @@ variable "repository" {
   description = "ECR repository URL"
   type        = string
 }
+
+variable "image_tag" {
+  description = "ECR image tag"
+  type        = string
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Number of tasks to run."
+}


### PR DESCRIPTION

- Added FastAPI application with health and redirect endpoints
- Configured container port mapping (8000) and ALB health check (/api/health/ready)
- Enabled CloudWatch logging for ECS tasks
- Validated redirect behavior behind ALB
- Set desired_count=1 to avoid inconsistent behavior (in-memory storage)

Note: Multi-task support will be enabled after introducing DynamoDB (M4).